### PR TITLE
Add Twilio support and action

### DIFF
--- a/.github/workflows/stock_update.yml
+++ b/.github/workflows/stock_update.yml
@@ -1,0 +1,44 @@
+name: Daily Tesla Update
+
+on:
+  schedule:
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+
+jobs:
+  run-script:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          pip install yfinance twilio
+      - name: Run update
+        env:
+          STOCK_EMAIL_SENDER: ${{ secrets.STOCK_EMAIL_SENDER }}
+          STOCK_EMAIL_RECEIVER: ${{ secrets.STOCK_EMAIL_RECEIVER }}
+          STOCK_EMAIL_PASSWORD: ${{ secrets.STOCK_EMAIL_PASSWORD }}
+          STOCK_SEND_EMAIL: ${{ secrets.STOCK_SEND_EMAIL }}
+          TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
+          TWILIO_AUTH_TOKEN: ${{ secrets.TWILIO_AUTH_TOKEN }}
+          TWILIO_FROM_NUMBER: ${{ secrets.TWILIO_FROM_NUMBER }}
+          TWILIO_TO_NUMBER: ${{ secrets.TWILIO_TO_NUMBER }}
+          STOCK_SEND_SMS: ${{ secrets.STOCK_SEND_SMS }}
+        run: python track_tesla.py
+
+  test-script:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install yfinance twilio
+      - name: Compile script
+        run: python -m py_compile track_tesla.py

--- a/README.md
+++ b/README.md
@@ -1,3 +1,62 @@
 # StockPriceTracking
 
 ## Tracking Tesla Stock Price
+
+This repository provides a simple script to check the latest Tesla (TSLA) stock
+price along with the maximum and minimum closing prices over the last five
+years.
+
+### Requirements
+
+- Python 3
+- `yfinance` (`pip install yfinance`)
+- `twilio` (`pip install twilio`) if you want SMS notifications
+
+### Usage
+
+Run the script to print the stock update:
+
+```bash
+python track_tesla.py
+```
+
+To send the update via email, set the following environment variables and enable
+email sending:
+
+```bash
+export STOCK_EMAIL_SENDER=your_email@example.com
+export STOCK_EMAIL_RECEIVER=destination_email@example.com
+export STOCK_EMAIL_PASSWORD=your_email_password
+export STOCK_SEND_EMAIL=1
+python track_tesla.py
+```
+
+To send the update via SMS using Twilio, set these variables:
+
+```bash
+export TWILIO_ACCOUNT_SID=your_account_sid
+export TWILIO_AUTH_TOKEN=your_auth_token
+export TWILIO_FROM_NUMBER=+1234567890
+export TWILIO_TO_NUMBER=+1234567890
+export STOCK_SEND_SMS=1
+python track_tesla.py
+```
+
+You can schedule the script daily using `cron` or run it via GitHub Actions.
+
+Create a workflow file at `.github/workflows/stock_update.yml` similar to the
+one in this repo. The workflow installs dependencies and runs the script daily.
+Add your email or Twilio credentials as repository secrets so they are not
+exposed in the workflow file.
+
+Alternatively, schedule with `cron`:
+
+```cron
+0 9 * * * /usr/bin/python /path/to/track_tesla.py >> /path/to/tesla.log 2>&1
+```
+
+### Disclaimer
+
+This script uses Yahoo Finance via `yfinance` and requires internet access.
+Email and SMS credentials should be stored securely (for example in environment
+variables or GitHub secrets) and never committed to the repository.

--- a/track_tesla.py
+++ b/track_tesla.py
@@ -1,0 +1,80 @@
+import os
+from datetime import datetime
+import yfinance as yf
+import smtplib
+from email.mime.text import MIMEText
+from twilio.rest import Client
+
+# Fetch last 5 years of Tesla (TSLA) data
+# Use period='5y' for last 5 years
+
+def get_stock_data():
+    # auto_adjust=False ensures the columns are simple floats with the usual
+    # Open/High/Low/Close/Volume structure
+    data = yf.download(
+        'TSLA', period='5y', auto_adjust=False, multi_level_index=False
+    )
+    if data.empty:
+        raise ValueError('No data fetched for TSLA')
+    close_series = data['Close']
+    latest_close = float(close_series.iloc[-1])
+    latest_date = data.index[-1].strftime('%Y-%m-%d')
+    max_price = float(close_series.max())
+    min_price = float(close_series.min())
+    return latest_date, latest_close, max_price, min_price
+
+
+def compose_message(latest_date, latest_close, max_price, min_price):
+    message = (
+        f"Tesla Stock Price Update for {latest_date}\n"
+        f"Latest Close Price: ${latest_close:.2f}\n"
+        f"5-Year Max Price: ${max_price:.2f}\n"
+        f"5-Year Min Price: ${min_price:.2f}\n"
+    )
+    return message
+
+
+def send_email(subject, body):
+    sender = os.environ.get('STOCK_EMAIL_SENDER')
+    receiver = os.environ.get('STOCK_EMAIL_RECEIVER')
+    password = os.environ.get('STOCK_EMAIL_PASSWORD')
+    if not all([sender, receiver, password]):
+        raise EnvironmentError('Email credentials not fully set')
+
+    msg = MIMEText(body)
+    msg['Subject'] = subject
+    msg['From'] = sender
+    msg['To'] = receiver
+
+    with smtplib.SMTP_SSL('smtp.gmail.com', 465) as smtp:
+        smtp.login(sender, password)
+        smtp.send_message(msg)
+
+
+def send_sms(body):
+    account_sid = os.environ.get('TWILIO_ACCOUNT_SID')
+    auth_token = os.environ.get('TWILIO_AUTH_TOKEN')
+    from_number = os.environ.get('TWILIO_FROM_NUMBER')
+    to_number = os.environ.get('TWILIO_TO_NUMBER')
+    if not all([account_sid, auth_token, from_number, to_number]):
+        raise EnvironmentError('Twilio credentials not fully set')
+
+    client = Client(account_sid, auth_token)
+    client.messages.create(body=body, from_=from_number, to=to_number)
+
+
+def main(send_mail=False, send_sms_flag=False):
+    latest_date, latest_close, max_price, min_price = get_stock_data()
+    message = compose_message(latest_date, latest_close, max_price, min_price)
+    if send_mail:
+        send_email('Tesla Stock Price Update', message)
+    if send_sms_flag:
+        send_sms(message)
+    if not send_mail and not send_sms_flag:
+        print(message)
+
+
+if __name__ == '__main__':
+    send_mail = bool(os.environ.get('STOCK_SEND_EMAIL'))
+    send_sms_flag = bool(os.environ.get('STOCK_SEND_SMS'))
+    main(send_mail, send_sms_flag)


### PR DESCRIPTION
## Summary
- update README with SMS setup and GitHub Actions usage
- add Twilio SMS notifications to `track_tesla.py`
- create workflow to run script daily and compile tests

## Testing
- `python -m py_compile track_tesla.py`
- `python track_tesla.py | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_6852284728848323810a49395756effa