### PR TITLE
Handle progress bar printing

### DIFF
--- a/.github/workflows/stock_update.yml
+++ b/.github/workflows/stock_update.yml
@@ -1,0 +1,39 @@
+name: Daily Tesla Update
+
+on:
+  schedule:
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+
+jobs:
+  run-script:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          pip install yfinance
+      - name: Run update
+        env:
+          STOCK_EMAIL_SENDER: ${{ secrets.STOCK_EMAIL_SENDER }}
+          STOCK_EMAIL_RECEIVER: ${{ secrets.STOCK_EMAIL_RECEIVER }}
+          STOCK_EMAIL_PASSWORD: ${{ secrets.STOCK_EMAIL_PASSWORD }}
+          STOCK_SEND_EMAIL: ${{ secrets.STOCK_SEND_EMAIL }}
+        run: python track_tesla.py
+
+  test-script:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install yfinance
+      - name: Compile script
+        run: python -m py_compile track_tesla.py

--- a/README.md
+++ b/README.md
@@ -1,3 +1,54 @@
 # StockPriceTracking
 
 ## Tracking Tesla Stock Price
+
+This repository provides a simple script to check the latest Tesla (TSLA) stock
+price along with the maximum and minimum closing prices over the last five
+years. It can optionally send the update via email.
+
+### Requirements
+
+- Python 3
+- `yfinance` (`pip install yfinance`)
+
+### Usage
+
+Run the script to print the stock update:
+
+```bash
+python track_tesla.py
+```
+
+To send the update via email, set the following environment variables and enable
+email sending:
+
+```bash
+export STOCK_EMAIL_SENDER=your_email@example.com
+export STOCK_EMAIL_RECEIVER=destination_email@example.com
+export STOCK_EMAIL_PASSWORD=your_email_password
+export STOCK_SEND_EMAIL=1  # accepts "1", "true", or "yes"
+python track_tesla.py
+```
+
+You can schedule the script daily using `cron` or run it via GitHub Actions.
+
+Create a workflow file at `.github/workflows/stock_update.yml` similar to the
+one in this repo. The workflow installs dependencies and runs the script daily.
+Add your email credentials as repository secrets so they are not exposed in the
+workflow file. The `STOCK_SEND_EMAIL` secret should be set to `1`, `true`, or
+`yes`.
+
+The stock information is printed to standard output. When using GitHub Actions,
+expand the "Run update" step in the job log to view the message.
+
+Alternatively, schedule with `cron`:
+
+```cron
+0 9 * * * /usr/bin/python /path/to/track_tesla.py >> /path/to/tesla.log 2>&1
+```
+
+### Disclaimer
+
+This script uses Yahoo Finance via `yfinance` and requires internet access.
+Email credentials should be stored securely (for example in environment
+variables or GitHub secrets) and never committed to the repository.

--- a/track_tesla.py
+++ b/track_tesla.py
@@ -1,0 +1,77 @@
+import os
+import yfinance as yf
+import smtplib
+from email.mime.text import MIMEText
+
+
+def _env_flag(name: str) -> bool:
+    """Return True if the environment variable is set to a truthy value."""
+    val = os.environ.get(name, "").lower()
+    return val in {"1", "true", "yes"}
+
+# Fetch last 5 years of Tesla (TSLA) data
+# Use period='5y' for last 5 years
+
+def get_stock_data():
+    # auto_adjust=False ensures the columns are simple floats with the usual
+    # Open/High/Low/Close/Volume structure
+    data = yf.download(
+        'TSLA',
+        period='5y',
+        auto_adjust=False,
+        multi_level_index=False,
+        progress=False,
+    )
+    if data.empty:
+        raise ValueError('No data fetched for TSLA')
+    close_series = data['Close']
+    latest_close = float(close_series.iloc[-1])
+    latest_date = data.index[-1].strftime('%Y-%m-%d')
+    max_price = float(close_series.max())
+    min_price = float(close_series.min())
+    return latest_date, latest_close, max_price, min_price
+
+
+def compose_message(latest_date, latest_close, max_price, min_price):
+    message = (
+        f"Tesla Stock Price Update for {latest_date}\n"
+        f"Latest Close Price: ${latest_close:.2f}\n"
+        f"5-Year Max Price: ${max_price:.2f}\n"
+        f"5-Year Min Price: ${min_price:.2f}\n"
+    )
+    return message
+
+
+def send_email(subject, body):
+    sender = os.environ.get('STOCK_EMAIL_SENDER')
+    receiver = os.environ.get('STOCK_EMAIL_RECEIVER')
+    password = os.environ.get('STOCK_EMAIL_PASSWORD')
+    if not all([sender, receiver, password]):
+        print('Email credentials not fully set; skipping email.')
+        return False
+
+    msg = MIMEText(body)
+    msg['Subject'] = subject
+    msg['From'] = sender
+    msg['To'] = receiver
+
+    with smtplib.SMTP_SSL('smtp.gmail.com', 465) as smtp:
+        smtp.login(sender, password)
+        smtp.send_message(msg)
+    return True
+
+
+def main(send_mail=False):
+    latest_date, latest_close, max_price, min_price = get_stock_data()
+    message = compose_message(latest_date, latest_close, max_price, min_price)
+    if send_mail:
+        sent = send_email('Tesla Stock Price Update', message)
+        if not sent:
+            print(message, flush=True)
+    else:
+        print(message, flush=True)
+
+
+if __name__ == '__main__':
+    send_mail = _env_flag('STOCK_SEND_EMAIL')
+    main(send_mail)


### PR DESCRIPTION
## Summary
- disable progress output from `yfinance.download`
- flush printed messages so they appear in logs
- document where to view GitHub Actions output

## Testing
- `python -m py_compile track_tesla.py`
- `python track_tesla.py | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_6852284728848323810a49395756effa